### PR TITLE
Global consent option

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.consentmo.com/"
 documentation: "https://support.consentmo.com/en/article/how-to-set-the-google-tag-manager-template-for-consentmo-gdpr-cmp-zlmfpg/"
 versions:
   # Latest version
-  - sha: a5b095a669d22486f07cad1b5f6153cc080503cb
-    changeNotes: Consent setting being handled by Consentmo's cookie bar script via onUserConsent
+  - sha: b18c8a4c36ba4012549f9a15583de68778bf98e5
+    changeNotes: Add global option to enable/ disable the set Default Consent through GTM.
   # Older version
+  - sha: a5b095a669d22486f07cad1b5f6153cc080503cb
+    changeNotes: Consent setting being handled by Consentmo's cookie bar script via onUserConsent.
   - sha: 3cfb94e78fd82885d8b3366ba68846f6a696a05e
     changeNotes: Add the option to set a specific initial consent for specific regions.
   - sha: 86d6636aca7aec4a842162b9fb45822e0798fcc3


### PR DESCRIPTION
Add a global option to enable/ disable the set Default Consent through GTM.

- Enable, set default consent through GTM CMP.
- Disable, default consent will be dynamically handled by Consentmo cookie bar.

Default value: Enable