### PR TITLE
Fix Consentmo GDPR CMP registration race on late-loading sites (Hydrogen)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.consentmo.com/"
 documentation: "https://support.consentmo.com/en/article/how-to-set-the-google-tag-manager-template-for-consentmo-gdpr-cmp-zlmfpg/"
 versions:
   # Latest version
+  - sha: d949eed825c7b285e7f4c60d924412335aff7648
+    changeNotes: Hydrogen retry on late load
+  # Older version
   - sha: fccb57bfa57fe5c1dc11141922f312751648120e
     changeNotes: Adding the developer ID2.
-  # Older version
   - sha: a3a234255db8744bcc8c3fec6962f644b17154e8
     changeNotes: Adding the developer ID.
   - sha: 0f010a2f121fe2dfad564a904829ef9204352d98

--- a/template.tpl
+++ b/template.tpl
@@ -272,6 +272,7 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
 const callLater = require('callLater');
 const getTimestampMillis = require('getTimestampMillis');
+const copyFromWindow = require('copyFromWindow');
 const log = require('logToConsole');
 const setDefaultConsentState = require('setDefaultConsentState');
 const updateConsentState = require('updateConsentState');

--- a/template.tpl
+++ b/template.tpl
@@ -270,6 +270,8 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
+const callLater = require('callLater');
+const getTimestampMillis = require('getTimestampMillis');
 const log = require('logToConsole');
 const setDefaultConsentState = require('setDefaultConsentState');
 const updateConsentState = require('updateConsentState');
@@ -388,7 +390,22 @@ const main = (settings) => {
     });
   }
 
-  callInWindow('gtmConsentmoCmp', onUserConsent);
+  // Poll until Consentmo defines gtmConsentmoCmp (Hydrogen / late load).
+  // callLater ≈ setTimeout(fn, 0) — no delay API in web GTM templates.
+  const startMs = getTimestampMillis();
+  const maxWaitMs = 5000; // 5 seconds
+  const tryRegister = () => {
+    if (copyFromWindow('gtmConsentmoCmp')) {
+      callInWindow('gtmConsentmoCmp', onUserConsent);
+      return;
+    }
+    if (getTimestampMillis() - startMs >= maxWaitMs) {
+      log('Consentmo CMP: gtmConsentmoCmp not available after timeout');
+      return;
+    }
+    callLater(tryRegister);
+  };
+  tryRegister();
 };
 
 main(settings);
@@ -437,7 +454,7 @@ ___WEB_PERMISSIONS___
                   },
                   {
                     "type": 8,
-                    "boolean": false
+                    "boolean": true
                   },
                   {
                     "type": 8,


### PR DESCRIPTION
## Summary
- Retry registration with `gtmConsentmoCmp` until the API is available (or 5s timeout), instead of a single `callInWindow` at Consent Initialization.
- Uses GTM `callLater` + `getTimestampMillis` (web templates have no `setTimeout` API).

## Why
On Hydrogen / headless setups, GTM often runs before Consentmo defines `gtmConsentmoCmp`. The one-shot call fails silently, so `isConsentmoCMPRegistered` stays false and Consent Mode stays denied until a full reload—even though Consentmo cookies/consent are already set.

## Behaviour
- Immediate success when Consentmo is already loaded (unchanged path).
- Polls via `callLater` until `copyFromWindow('gtmConsentmoCmp')` is truthy, then `callInWindow('gtmConsentmoCmp', onUserConsent)` (one argument only).
- Stops after `maxWaitMs = 5000` if the API never appears.

## Test plan
- [ ] Theme / standard Shopify: Accept → Consent Mode updates without reload; `isConsentmoCMPRegistered === true`
- [ ] Hydrogen / late Consentmo load: same after Accept; no stuck `G100` / denied GCS on first pageview
- [ ] Consentmo never loads: template logs timeout and exits cleanly (no infinite loop)
- [ ] Existing cookie restore / region defaults / discard-init behaviour unchanged