### PR TITLE
Support versioned cookieconsent_status cookies in GTM

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,9 +2,11 @@ homepage: "https://www.consentmo.com/"
 documentation: "https://support.consentmo.com/en/article/how-to-set-the-google-tag-manager-template-for-consentmo-gdpr-cmp-zlmfpg/"
 versions:
   # Latest version
+  - sha: a578c0bd487b6dae62f25d057461aa8094c65439
+    changeNotes: Support versioned cookieconsent_status cookies.
+  # Older version
   - sha: fccb57bfa57fe5c1dc11141922f312751648120e
     changeNotes: Adding the developer ID2.
-  # Older version
   - sha: a3a234255db8744bcc8c3fec6962f644b17154e8
     changeNotes: Adding the developer ID.
   - sha: 0f010a2f121fe2dfad564a904829ef9204352d98

--- a/template.tpl
+++ b/template.tpl
@@ -279,6 +279,7 @@ const gtagSet = require('gtagSet');
 const makeNumber = require('makeNumber');
 const cookieConsentStatus = 'cookieconsent_status';
 const cookieConsentDisabled = 'cookieconsent_preferences_disabled';
+const cookieConsentStatusMaxIndex = 50;
 const settings = {
   setDefaultConsent: data.setDefaultConsent !== undefined ? (data.setDefaultConsent || false) : true,
   security: 'granted',
@@ -295,6 +296,21 @@ const settings = {
 const _getCookie = (cookieName) => {
   const values = getCookieValues(cookieName);
   return values && values.length > 0 ? values[0] : undefined;
+};
+
+const _getConsentStatusCookie = () => {
+  let value = _getCookie(cookieConsentStatus);
+  let i = 1;
+  while (i <= cookieConsentStatusMaxIndex) {
+    const next = _getCookie(cookieConsentStatus + i);
+    if (next !== undefined) {
+      value = next;
+    } else if (value !== undefined) {
+      break;
+    }
+    i = i + 1;
+  }
+  return value;
 };
 
 const getConsentValues = () => {
@@ -375,7 +391,7 @@ const main = (settings) => {
     gtagSet('developer_id.dNDdkZG', true);
   }
 
-  if ((settings.regionSettings || settings.setDefaultConsent) && _getCookie(cookieConsentStatus) !== undefined) {
+  if ((settings.regionSettings || settings.setDefaultConsent) && _getConsentStatusCookie() !== undefined) {
     const consentValues = getConsentValues();
     updateConsentState({
       security_storage: consentValues.security,
@@ -795,23 +811,7 @@ ___WEB_PERMISSIONS___
           "key": "cookieAccess",
           "value": {
             "type": 1,
-            "string": "specific"
-          }
-        },
-        {
-          "key": "cookieNames",
-          "value": {
-            "type": 2,
-            "listItem": [
-              {
-                "type": 1,
-                "string": "cookieconsent_status"
-              },
-              {
-                "type": 1,
-                "string": "cookieconsent_preferences_disabled"
-              }
-            ]
+            "string": "any"
           }
         }
       ]


### PR DESCRIPTION
- Resolve consent from versioned cookieconsent_status cookies (cookieconsent_status, cookieconsent_status1, …), using the highest existing suffix
- Keep cookieconsent_preferences_disabled as a single fixed cookie name
- Broaden cookie read permission so versioned status cookies can be read